### PR TITLE
Raise an exception on failed auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,18 @@ module ApplicationCable
     # `owned_by` instruction
     owned_by current_user : User
 
+
     def connect
-      UserToken.decode_user_id(token.to_s).try do |user_id|
-        self.identifier = user_id.to_s
-        self.current_user =  UserQuery.find(user_id)
+      user_id : Int64? = UserToken.decode_user_id(token.to_s)
+
+      # We were unable to authenticate the user, we should raise an
+      # unauthorized exception
+      if !user_id
+          raise UnathorizedConnectionException.new
       end
+
+      self.identifier = user_id.to_s
+      self.current_user =  UserQuery.find(user_id)
     end
 
   end


### PR DESCRIPTION
@jwoertink during #26 we forgot to reject the connection on a failed auth

I'm using `raise UnathorizedConnectionException.new` instead of `reject_unauthorized_connection` just because I find it more explicit.