### PR TITLE
Wrap the Connection::CHANELS in a mutex to help thread safety

### DIFF
--- a/src/cable.cr
+++ b/src/cable.cr
@@ -1,3 +1,6 @@
+require "mutex"
+require "set"
+require "uuid"
 require "habitat"
 require "json"
 require "./cable/**"

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -1,6 +1,3 @@
-require "mutex"
-require "set"
-
 module Cable
   alias Channels = Set(Cable::Channel)
 


### PR DESCRIPTION
This PR adds a global mutex for the `Connect::CHANNELS`. I have a feeling with all of the upcoming Crystal multithreadding updates that this shard would not do so well... So in order to get it more thread safe, I wanted to start working on some PRs to help that.

I really don't know the best way to test if these changes actually help or hurt, so if anyone has any ideas, I'm all ears.

/cc. @jgaskins @fernandes 