### PR TITLE
Log broadcasts once per event instead of once per subscriber (#73)

### DIFF
--- a/spec/cable/server_spec.cr
+++ b/spec/cable/server_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "log/spec"
 
 include RequestHelpers
 
@@ -44,6 +45,34 @@ describe Cable::Server do
 
         Cable.server.active_connections_for("def456").size.should eq(0)
       end
+    end
+  end
+
+  describe "#send_to_channels" do
+    it "logs a single line per broadcast regardless of the number of subscribers" do
+      Cable.reset_server
+      Cable.temp_config(backend_class: Cable::DevBackend) do
+        connection_1 = creates_new_connection("aa")
+        connection_2 = creates_new_connection("bb")
+
+        Cable.server.add_connection(connection_1)
+        Cable.server.add_connection(connection_2)
+
+        # Both connections stream from the same identifier ("chat_room_a")
+        connection_1.subscribe(subscribe_payload("room_a"))
+        connection_2.subscribe(subscribe_payload("room_a"))
+
+        logs = Log.capture("cable") do
+          Cable.server.send_to_channels("chat_room_a", {"message" => "hi"}.to_json)
+        end
+
+        logs.check(:info, /Transmitting .* to 2 subscribers \(via streamed from chat_room_a\)/)
+        logs.empty
+
+        connection_1.close
+        connection_2.close
+      end
+      Cable.reset_server
     end
   end
 

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -135,6 +135,7 @@ module Cable
       return unless @channels.has_key?(channel_identifier)
 
       parsed_message = safe_decode_message(message)
+      transmitted = 0
 
       begin
         @channels[channel_identifier].each do |channel|
@@ -143,12 +144,18 @@ module Cable
           if channel.connection.closed?
             channel.close
           else
-            Cable::Logger.info { "#{channel.class} transmitting #{parsed_message} (via streamed from #{channel.stream_identifier})" }
             channel.connection.socket.send({
               identifier: channel.identifier,
               message:    parsed_message,
             }.to_json)
+            transmitted += 1
           end
+        end
+
+        # Log once per broadcast event rather than once per subscriber, so a
+        # message fanned out to N connections produces a single log line.
+        if transmitted > 0
+          Cable::Logger.info { "Transmitting #{parsed_message} to #{transmitted} subscriber#{"s" if transmitted > 1} (via streamed from #{channel_identifier})" }
         end
       rescue e : IO::Error
         Cable.settings.on_error.call(e, "IO::Error Exception: #{e.message}: #{parsed_message} -> Cable::Server#send_to_channels(channel, message)", nil)


### PR DESCRIPTION
## Problem

Fixes #73.

`Cable::Server#send_to_channels` logged the "transmitting" line **inside** the per-subscriber loop:

```crystal
@channels[channel_identifier].each do |channel|
  ...
  Cable::Logger.info { "#{channel.class} transmitting #{parsed_message} (via streamed from #{channel.stream_identifier})" }
  channel.connection.socket.send(...)
end
```

So broadcasting one message to a stream with N connected clients produced N identical log lines. A chat room with 100 viewers logged `"hi"` 100 times; the only workaround was `Cable::Logger.level = :none`, which silences all Cable logging.

## Change

Move the log outside the loop and emit a **single line per broadcast event**, including the number of subscribers it was delivered to:

```
Transmitting {"message" => "hi"} to 13 subscribers (via streamed from chat_room_1)
```

- Counts only live connections actually transmitted to (closed connections are still reaped in the loop as before).
- Skips the log entirely when there are no live subscribers.

The redundant per-message broadcast is still logged once at the call site (`Channel#broadcast` / `.broadcast_to`), so no information is lost.

## Tests

Added `spec/cable/server_spec.cr#send_to_channels` — subscribes two connections to the same stream, captures logs, and asserts exactly one info line (`... to 2 subscribers ...`) is emitted. Full suite green (52 examples, 0 failures); `ameba` clean.

## Note

This changes the log line format (`<Class> transmitting <msg> (via streamed from <id>)` → `Transmitting <msg> to <n> subscribers (via streamed from <id>)`). Anything grepping the old string will need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)