### PR TITLE
Close fiber_channel on Server#shutdown to avoid fiber leak. Fixes #110

### DIFF
--- a/spec/cable/server_spec.cr
+++ b/spec/cable/server_spec.cr
@@ -18,6 +18,25 @@ describe Cable::Server do
     end
   end
 
+  describe "#shutdown" do
+    it "closes the fiber_channel so the subscribed messages fiber doesn't leak" do
+      Cable.reset_server
+      Cable.temp_config(backend_class: Cable::DevBackend) do
+        server = Cable.server
+        server.fiber_channel.closed?.should be_false
+
+        server.shutdown
+
+        server.fiber_channel.closed?.should be_true
+        # Sending to the closed channel must raise rather than silently leak.
+        expect_raises(::Channel::ClosedError) do
+          server.fiber_channel.send({"foo", "bar"})
+        end
+      end
+      Cable.reset_server
+    end
+  end
+
   describe "#active_connections_for" do
     it "accurately returns active connections for a specificic token" do
       Cable.reset_server

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -195,6 +195,9 @@ module Cable
       connections_to_close.each do |connection|
         connection.close
       end
+      # Close the channel so the `process_subscribed_messages` fiber stops
+      # blocking on `receive` and exits cleanly instead of leaking across restarts.
+      fiber_channel.close
     end
 
     def restart?
@@ -210,7 +213,7 @@ module Cable
     private def process_subscribed_messages
       server = self
       spawn(name: "Cable::Server - process_subscribed_messages") do
-        while received = fiber_channel.receive
+        while received = fiber_channel.receive?
           channel, message = received
           if channel.starts_with?("cable_internal")
             identifier = channel.split('/').last


### PR DESCRIPTION
## Problem

During `Server#shutdown` the `fiber_channel` (`::Channel({String, String})`) was never closed. The `process_subscribed_messages` fiber reads from it in a forever-loop (`while received = fiber_channel.receive`), and the producer side lives in the external `cable-redis` shard (`Cable.server.fiber_channel.send(...)`).

Because `Cable.restart` builds a brand-new `Server` — with a brand-new `fiber_channel` — on every restart, each shutdown left the old fiber blocked on `receive` against an orphaned channel. That's a fiber + channel leak that accumulates across restarts.

Fixes #110.

## Changes

- `Server#shutdown` now calls `fiber_channel.close` after closing connections (where the issue author suggested).
- The receive loop switches from `receive` to `receive?`. This is necessary because calling `receive` on a closed channel raises `Channel::ClosedError`, which would crash the spawned fiber with an unhandled exception. `receive?` returns `nil` on close, so the loop exits cleanly.

## Tests

- Added a regression spec in `spec/cable/server_spec.cr` asserting that after `shutdown` the `fiber_channel` is closed and a subsequent `send` raises.
- Full suite passes: **52 examples, 0 failures, 0 errors, 0 pending**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)